### PR TITLE
Fixed edge case

### DIFF
--- a/src/main/java/com/floweytf/tfcsupportindicator/CollapseComponentProvider.java
+++ b/src/main/java/com/floweytf/tfcsupportindicator/CollapseComponentProvider.java
@@ -40,7 +40,7 @@ public enum CollapseComponentProvider implements IBlockComponentProvider {
                 pos.offset(-4, -2, -4),
                 pos.offset(4, 2, 4)
             ).stream()
-            .anyMatch(u -> CollapseRecipe.canStartCollapse(level, u));
+            .anyMatch(u -> CollapseRecipe.canStartCollapse(level, u) && !u.equals(pos));
 
         tooltip.add(isSupported ? SELF_SUPPORTED : SELF_UNSUPPORTED);
         tooltip.add(mightTriggerCollapse ? MIGHT_TRIGGER_COLLAPSE : WONT_TRIGGER_COLLAPSE);


### PR DESCRIPTION
When looking at an unsupported block with no other unsupported blocks in range, the tooltip says "Might trigger collapse" because the block is detecting itself. However, collapses can't be triggered by a block that has been broken so this is inaccurate.

Previous behaviour:
<img width="2558" height="1401" alt="2026-02-04_12 47 19" src="https://github.com/user-attachments/assets/e0a21b6f-ae89-4244-8eea-9c720c28b949" />

Correct behaviour:
<img width="2558" height="1401" alt="2026-02-04_12 45 30" src="https://github.com/user-attachments/assets/a42f858d-4f6c-44aa-b7f3-d16140e82165" />
